### PR TITLE
Make SSE work for different chat windows

### DIFF
--- a/backend-nabu/controllers/MessagesController.ts
+++ b/backend-nabu/controllers/MessagesController.ts
@@ -16,6 +16,8 @@ export async function CreateNewMessage(req: Request, res: Response, prisma: Pris
       }
     })
     notSyncedMessages.push({...message, createdAt: `${message.createdAt}`, updatedAt: `${message.updatedAt}`})
+    console.log("Created message. Return json: ")
+    console.log({message: message, status: "ok"})
     res.json({message: message, status: "ok"})
   }
 }

--- a/backend-nabu/controllers/MessagesPushController.ts
+++ b/backend-nabu/controllers/MessagesPushController.ts
@@ -41,6 +41,8 @@ export async function createAndRunMessageEvent(req: Request, res: Response, not_
     }
 
     if (notSyncedForUUID.length > 0) {
+      console.log("Sending new messages to user: " + req.query.clientUUID)
+      console.log(JSON.stringify(notSyncedForUUID))
       res.write("data: " + JSON.stringify(notSyncedForUUID) +  '\n\n');
       var client = clientUUIDSyncArray.find(client => client.clientUUID === String(req.query.clientUUID))
       if (client) {

--- a/frontend-nabu/src/App.tsx
+++ b/frontend-nabu/src/App.tsx
@@ -10,7 +10,13 @@ const initial_channels: channelsArray = []
 function App() {
   const [channels, setChannels] = React.useState(initial_channels)
 
-  const [activeChannelId, setActiveChannelId] = React.useState(0)
+  const [activeChannelId, _setActiveChannelId] = React.useState(0)
+
+  const activeChannelIdRef = React.useRef(activeChannelId)
+  function setActiveChannelId(data: number) {
+    activeChannelIdRef.current = data
+    _setActiveChannelId(data)
+  }
 
   React.useEffect(() => {
     var activeIndex = channels.findIndex(x => x.status == "active")
@@ -20,6 +26,7 @@ function App() {
   }, [channels])
 
   function updateActiveChannel(channelId: number) {
+    setActiveChannelId(channelId)
     setChannels((state: channelsArray) => {
       var clickedIndex = state.findIndex(x => x.id == channelId);
       var lastActiveIndex = state.findIndex(x => x.status == "active")
@@ -38,7 +45,7 @@ function App() {
       <Navigation channels={channels} updateActiveChannel={updateActiveChannel}/>
       <div className="main">
         <ChannelList channels={channels} setChannels={setChannels} updateActiveChannel={updateActiveChannel}/>
-        <Chat activeChannelId={activeChannelId}/>
+        <Chat activeChannelId={activeChannelIdRef.current}/>
       </div>
     </div>
   );

--- a/frontend-nabu/src/App.tsx
+++ b/frontend-nabu/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
 
   const activeChannelIdRef = React.useRef(activeChannelId)
   function setActiveChannelId(data: number) {
+    console.log("Setting ActiveChannelId To: " + data)
     activeChannelIdRef.current = data
     _setActiveChannelId(data)
   }
@@ -45,7 +46,7 @@ function App() {
       <Navigation channels={channels} updateActiveChannel={updateActiveChannel}/>
       <div className="main">
         <ChannelList channels={channels} setChannels={setChannels} updateActiveChannel={updateActiveChannel}/>
-        <Chat activeChannelId={activeChannelIdRef.current}/>
+        <Chat activeChannelIdRef={activeChannelIdRef}/>
       </div>
     </div>
   );

--- a/frontend-nabu/src/components/Chat.tsx
+++ b/frontend-nabu/src/components/Chat.tsx
@@ -13,6 +13,10 @@ function Chat(props: {activeChannelIdRef: React.MutableRefObject<number>}) {
   const [lastMessageId, setLastMessageId] = React.useState(0)
 
   React.useEffect(() => {
+    setServerSideEvents(setMessages, props.activeChannelIdRef, lastMessageId)
+  }, [])
+
+  React.useEffect(() => {
     if (props.activeChannelIdRef.current !== 0) {
       GetAllMessages(props.activeChannelIdRef.current).then((res: {messages: messageType[], status: string}) => {
         if (res.status === "ok") {
@@ -22,7 +26,6 @@ function Chat(props: {activeChannelIdRef: React.MutableRefObject<number>}) {
             lastMessageId = sortedMessages[0].id
           }
           setLastMessageId(lastMessageId)
-          setServerSideEvents(setMessages, props.activeChannelIdRef, lastMessageId)
           setMessages(res.messages)
         } else {
           //

--- a/frontend-nabu/src/components/Chat.tsx
+++ b/frontend-nabu/src/components/Chat.tsx
@@ -8,13 +8,13 @@ export type messagesArray = Array<messageType>
 const initial_messages: messagesArray = []
 
 
-function Chat(props: {activeChannelId: number}) {
+function Chat(props: {activeChannelIdRef: React.MutableRefObject<number>}) {
   const [messages, setMessages] = React.useState(initial_messages)
   const [lastMessageId, setLastMessageId] = React.useState(0)
 
   React.useEffect(() => {
-    if (props.activeChannelId !== 0) {
-      GetAllMessages(props.activeChannelId).then((res: {messages: messageType[], status: string}) => {
+    if (props.activeChannelIdRef.current !== 0) {
+      GetAllMessages(props.activeChannelIdRef.current).then((res: {messages: messageType[], status: string}) => {
         if (res.status === "ok") {
           var lastMessageId = 0
           if (res.messages.length > 0) {
@@ -22,14 +22,14 @@ function Chat(props: {activeChannelId: number}) {
             lastMessageId = sortedMessages[0].id
           }
           setLastMessageId(lastMessageId)
-          setServerSideEvents(setMessages, props.activeChannelId, lastMessageId)
+          setServerSideEvents(setMessages, props.activeChannelIdRef, lastMessageId)
           setMessages(res.messages)
         } else {
           //
         }
       })
     }
-  }, [props.activeChannelId])
+  }, [props.activeChannelIdRef.current])
 
 
   async function newMessage(message: messageType) {
@@ -47,7 +47,7 @@ function Chat(props: {activeChannelId: number}) {
   return (
     <div className="chat">
       <ChatMessages messages={messages} retrySendingMessage={retrySendingMessage}/>
-      <ChatTextField newMessage={newMessage} activeChannelId={props.activeChannelId}/>
+      <ChatTextField newMessage={newMessage} activeChannelIdRef={props.activeChannelIdRef}/>
     </div>
   )
 }

--- a/frontend-nabu/src/components/ChatTextField.tsx
+++ b/frontend-nabu/src/components/ChatTextField.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-function ChatTextField(props: {newMessage: Function, activeChannelId: number}) {
+function ChatTextField(props: {newMessage: Function, activeChannelIdRef: React.MutableRefObject<number>}) {
   const [message, updateMessage] = React.useState("")
 
   function handleChange(e: React.FormEvent<HTMLInputElement>) {
@@ -10,7 +10,7 @@ function ChatTextField(props: {newMessage: Function, activeChannelId: number}) {
 
   function sendMessage(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    props.newMessage({id: 0, sender: "Qnsi", text: message, status: "waiting", channelId: props.activeChannelId})
+    props.newMessage({id: 0, sender: "Qnsi", text: message, status: "waiting", channelId: props.activeChannelIdRef.current})
     updateMessage("")
   }
   return (

--- a/frontend-nabu/src/controllers/MessagesController.ts
+++ b/frontend-nabu/src/controllers/MessagesController.ts
@@ -48,17 +48,17 @@ export async function GetAllMessages(channelId: number): Promise<{messages: mess
   })
 }
 
-export function setServerSideEvents(setMessages: Function, activeChannelId: number, lastMessageId: number) {
+export function setServerSideEvents(setMessages: Function, activeChannelIdRef: React.MutableRefObject<number>, lastMessageId: number) {
   var clientUUID = crypto.randomUUID()
-  var eventSource = new EventSource(`http://localhost:3001/messages_event?channelId=${activeChannelId}&lastMessageId=${lastMessageId}&clientUUID=${clientUUID}`);
+  var eventSource = new EventSource(`http://localhost:3001/messages_event?channelId=${activeChannelIdRef.current}&lastMessageId=${lastMessageId}&clientUUID=${clientUUID}`);
 
   eventSource.onmessage = e => {
-    console.log("Inside eventSource on message. ActiveChannelId: " + activeChannelId)
+    console.log("Inside eventSource on message. ActiveChannelId: " + activeChannelIdRef.current)
     const messages = parseMessagesFromJson(JSON.parse(e.data))
     setMessages((state: messagesArray) => {
       var notSyncedMessages: messagesArray = []
       for (let message of messages) {
-        if (message.channelId === activeChannelId) {
+        if (message.channelId === activeChannelIdRef.current) {
           var index = state.findIndex(state_message => state_message.id === message.id) 
           if (index === -1) {
             notSyncedMessages.push(message)

--- a/tests/messageFromOthers.spec.ts
+++ b/tests/messageFromOthers.spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from "@playwright/test"
-import { sendMessage } from "./testHelpers.spec";
+import { sendMessage, switchToChannel } from "./testHelpers.spec";
 
 test("when other user sends message we should get it pushed", async ({ page, context }) => {
   await page.goto("http://localhost:3001/dangerous/only_in_dev/clear_database")
@@ -13,3 +13,15 @@ test("when other user sends message we should get it pushed", async ({ page, con
   await expect(await chat_message.isVisible()).toBe(true)
   await expect(chat_message).toHaveText("Qnsi: Hello world!")
 });
+
+test("message sent from another user to different channel should go to correct channel", async ({ page, context}) => {
+      await page.goto("http://localhost:3001/dangerous/only_in_dev/clear_database")
+      await page.goto("http://localhost:3000/")
+      const second_page = await context.newPage();
+      await second_page.goto("http://localhost:3000/")
+      await switchToChannel(second_page, "random")
+      await sendMessage(page, "Hello world!")
+      await second_page.waitForTimeout(1100)
+      const chat_message = second_page.locator(".chat-message:has-text('Hello world!')")
+      await expect(await chat_message.isVisible()).toBe(false)
+})

--- a/tests/testHelpers.spec.ts
+++ b/tests/testHelpers.spec.ts
@@ -4,3 +4,7 @@ export async function sendMessage(page: Page, message: string) {
   await page.fill(".chat-text-field", message);
   await page.click("text=Send")
 }
+
+export async function switchToChannel(page: Page, channelName: string) {
+  await page.click(`.channel:has-text('${channelName}')`)
+}


### PR DESCRIPTION
I had to use useRef for `onmessage` event listener to have `activeChannelId` refresh. Also, I was setting multiple event listeners which caused hard to debug bug. Now should work like a charm.


Opens path to have unread messages badges in not active channels. 