### PR TITLE
Clear unread badge when moving to unread channel

### DIFF
--- a/frontend-nabu/src/App.css
+++ b/frontend-nabu/src/App.css
@@ -83,5 +83,5 @@ body {
 
 .chat-messages {
   flex-grow: 50;
-  margin-left: 5%;
+  margin-left: 1%;
 }

--- a/frontend-nabu/src/components/Chat.tsx
+++ b/frontend-nabu/src/components/Chat.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ChatTextField from "./ChatTextField";
 import ChatMessages from "./ChatMessages";
 import { CreateNewMessage, GetAllMessages, setServerSideEvents } from "../controllers/MessagesController";
+import { unreadType } from "../App";
 
 export type messageType = {id: number, channelId: number, sender: string, text: string, status: string}
 export type messagesArray = Array<messageType>
@@ -32,6 +33,15 @@ function Chat(props: {activeChannelIdRef: React.MutableRefObject<number>, setUnr
           }
           setLastMessageId(lastMessageId)
           setMessages(res.messages)
+          props.setUnreads((state: unreadType[]) => {
+            return state.map((unread) => {
+              if (unread.channelId === props.activeChannelIdRef.current) {
+                return {...unread, count: 0}
+              } else {
+                return unread
+              }
+            })
+          })
         } else {
           //
         }

--- a/tests/unreadMessages/gettingMessageInDifferentChannel.spec.ts
+++ b/tests/unreadMessages/gettingMessageInDifferentChannel.spec.ts
@@ -9,9 +9,14 @@ test("when other user sends message we should get it pushed", async ({ page, con
   await switchToChannel(second_page, "random")
   await sendMessage(second_page, "Hello world!")
 
+  // badge should be visible
   await page.waitForTimeout(1100)
-  // const chat_message = page.locator(".channel-parent:has-text('random') > channel-unread")
-  const chat_message = page.locator(".channel-parent:has-text('random') > .channel-unread")
-  await expect(await chat_message.isVisible()).toBe(true)
-  await expect(chat_message).toHaveText("1")
+  const unread_badge = page.locator(".channel-parent:has-text('random') > .channel-unread")
+  await expect(await unread_badge.isVisible()).toBe(true)
+  await expect(unread_badge).toHaveText("1")
+
+  // moving to channel should clear the badge
+  await switchToChannel(page, "random")
+  const unread_badge2 = page.locator(".channel-parent:has-text('random') > .channel-unread")
+  await expect(await unread_badge2.isVisible()).toBe(false)
 });


### PR DESCRIPTION
Pretty easy fix, altough the code is getting pretty hard to read. I will try to clean in next PR